### PR TITLE
Infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+data.xml
+node_modules/
+specgen_input/
+test/
+objs.txt
+typegraph.txt
+objectgraph.txt
+package.json
+package-lock.json
+scripts/

--- a/README.adoc
+++ b/README.adoc
@@ -121,6 +121,8 @@ npm install fs
 npm install dot-object
 ----
 
+Another little utility that you will need is: jq which you can download from https://stedolan.github.io/jq/[github]
+
 Lastly you need to make the shell scripts executable:
 
 [source,console]

--- a/inf_extract.sh
+++ b/inf_extract.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Script to extract specgen information from raw Infrastructure specgen input files
+
+# Setup - we need case insensitive string matching - or we'll lose (xQuery.xml)
+shopt -s nocasematch   
+
+
+# 1. Download specgen
+#rm -fr specgen_input
+#git clone https://github.com/nsip/DraftSIFInfrastructureSpec.git
+
+
+# 2. Extract all necessary information from specgen into flat files
+#    Start off with empty files...
+echo "" > objectgraph.txt
+echo "" > typegraph.txt
+
+# process all objects in the specification
+containsElement () {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
+
+xsltproc included_objects.xslt specgen_input/06_DataModel/Custom/DataModel-Infrastructure.xml | perl -ne 'next unless $_ =~ /\S/; next if $_ =~ /<\?/; s/^\s+//; s/\s+$//; print "./specgen_input/06_DataModel/Custom/" . $_ . "\n"' > objs.txt
+IFS=$'\n' read -d '' -r -a objectarray < objs.txt
+
+for filename in ./specgen_input/06_DataModel/Custom/Infrastructure/*.xml; do
+  if containsElement "$filename" "${objectarray[@]}" ; then
+    :
+  else
+    echo "Excluded:" $filename;
+    continue;
+  fi
+  xsltproc sifobject.xslt "$filename" >> objectgraph.txt
+
+  # Infrastructure re-uses some object complexTypes in other objects
+  xsltproc --stringparam objSuffix Type sifobject.xslt "$filename" >>typegraph.txt
+done
+
+# process all common types in the specification
+echo '<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns="http://sifassociation.org/SpecGen" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xhtml="http://www.w3.org/1999/xhtml" >' > data.xml
+cat specgen_input/80_BackMatter/Generic-CommonTypes.xml >> data.xml
+cat specgen_input/80_BackMatter/Custom/DataModel-CommonTypes-Custom.xml >> data.xml
+echo '</root>' >> data.xml
+xsltproc sifobject.xslt data.xml >> typegraph.txt
+

--- a/makejs2xml.rb
+++ b/makejs2xml.rb
@@ -43,7 +43,7 @@ end
 print <<~"END"
 let X2JS = require('x2js');
 const fs = require("fs");
-const js = fs.readFileSync("/dev/stdin", "utf-8");
+const js = fs.readFileSync(0, "utf-8");
 var dot = require('dot-object');
 
 var attrpaths = new Object;

--- a/makexslt.rb
+++ b/makexslt.rb
@@ -146,8 +146,8 @@ print <<~"END"
   </xsl:template>
 
   <!-- simple content with attribute -->
-  <xsl:template match="#{simpleattr.join(' | ')}" mode="detect">
-    <xsl:text>"</xsl:text><xsl:value-of select="name()"/>" : <xsl:apply-templates select="." mode="obj-content" priority="1"/>
+  <xsl:template match="#{simpleattr.join(' | ')}" mode="detect" priority="1">
+    <xsl:text>"</xsl:text><xsl:value-of select="name()"/>" : <xsl:apply-templates select="." mode="obj-content"/>
     <xsl:if test="count(following-sibling::*) &gt; 0">, </xsl:if>
   </xsl:template>
 

--- a/makexslt.rb
+++ b/makexslt.rb
@@ -153,7 +153,8 @@ print <<~"END"
 
   <!-- list -->
   <xsl:template match="#{list.join(' | ')}" mode="detect">
-  <xsl:if test="count(preceding-sibling::*) = 0">
+  <!-- repeating item may not be wrapped up in a List element (so check names of preceding-siblings) -->
+  <xsl:if test="count(preceding-sibling::*) = 0 or not(name(preceding-sibling::*[1]) = name(.))">
       <xsl:text>"</xsl:text><xsl:value-of select="name()"/><xsl:text>" : [</xsl:text>
     </xsl:if>
     <xsl:choose>
@@ -164,9 +165,10 @@ print <<~"END"
         <xsl:apply-templates select="." mode="value"/>
       </xsl:when>
     </xsl:choose>
-    <xsl:if test="count(following-sibling::*) &gt; 0">, </xsl:if>
-    <xsl:if test="count(following-sibling::*) = 0"><xsl:text>]</xsl:text></xsl:if>
-  </xsl:template>
+    <!-- repeating item may not be wrapped up in a List element (so check names of following-siblings) -->
+    <xsl:if test="count(following-sibling::*) &gt; 0 and name(following-sibling::*[1]) = name(.)">, </xsl:if>
+    <xsl:if test="count(following-sibling::*) = 0 or not(name(following-sibling::*[1]) = name(.))"><xsl:text>]</xsl:text><xsl:if test="count(following-sibling::*) &gt; 0"><xsl:text>,</xsl:text></xsl:if></xsl:if>
+  </xsl:template>  
 
   <xsl:template match="*" mode="obj-content">
     <xsl:text>{</xsl:text>

--- a/makexslt.rb
+++ b/makexslt.rb
@@ -147,12 +147,12 @@ print <<~"END"
 
   <!-- simple content with attribute -->
   <xsl:template match="#{simpleattr.join(' | ')}" mode="detect">
-    <xsl:text>"</xsl:text><xsl:value-of select="name()"/>" : <xsl:apply-templates select="." mode="obj-content" />
+    <xsl:text>"</xsl:text><xsl:value-of select="name()"/>" : <xsl:apply-templates select="." mode="obj-content" priority="1"/>
     <xsl:if test="count(following-sibling::*) &gt; 0">, </xsl:if>
   </xsl:template>
 
-  <!-- list -->
-  <xsl:template match="#{list.join(' | ')}" mode="detect">
+  <!-- list  - takes precedence when list of elements which are simple content with attributes -->
+  <xsl:template match="#{list.join(' | ')}" mode="detect" priority="2">
   <!-- repeating item may not be wrapped up in a List element (so check names of preceding-siblings) -->
   <xsl:if test="count(preceding-sibling::*) = 0 or not(name(preceding-sibling::*[1]) = name(.))">
       <xsl:text>"</xsl:text><xsl:value-of select="name()"/><xsl:text>" : [</xsl:text>

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+
+#  Run ONE of the following to setup  objectgraph.txt and typegraph.txt
 #sh au_extract.sh
+#sh inf_extract.sh
 #sh input_extract.sh
 
 # 3. Generate transformation scripts and stylesheets
@@ -11,36 +14,53 @@ ruby makexslt.rb -p < scripts/out.txt > scripts/sif2jsonspecgen.xslt
 ruby makereorder.rb < scripts/out.txt > scripts/sifreorder.xslt
 ruby makejs2xml.rb < scripts/out.txt > scripts/json2sif.js
 
-
 # 4. Extract example XML from specgen
 mkdir -p test
 echo "<sif>" > test/siftest.xml 
-for filename in ./specgen_input/06_DataModel/Custom/Common/*.xml; do
-#for filename in ./specgen/GenerateSpecTool_5/bin/Debug/dist/Specification/06_DataModel/Custom/Common/*.xml; do
-  if [[ "$filename" == "./specgen_input/06_DataModel/Custom/Common/StudentScoreSet.xml" ]] || [[ "$filename" == "./specgen_input/06_DataModel/Custom/Common/PersonPrivacyObligation.xml" ]] || [[ "$filename" == "./specgen_input/06_DataModel/Custom/Common/ReportAuthorityInfo.xml" ]] ; then
-  #if [[ "$filename" == "./specgen/GenerateSpecTool_5/bin/Debug/dist/Specification/06_DataModel/Custom/Common/StudentScoreSet.xml" ]]; then
-    continue
-  fi
-  perl sifexamples.pl "$filename" >> test/siftest.xml
-done
-for filename in ./specgen_input/06_DataModel/Custom/AU/*.xml; do
-#for filename in ./specgen/GenerateSpecTool_5/bin/Debug/dist/Specification/06_DataModel/Custom/AU/*.xml; do
-  if [[ "$filename" == "./specgen_input/06_DataModel/Custom/Common/StudentScoreSet.xml" ]] || [[ "$filename" == "./specgen_input/06_DataModel/Custom/Common/PersonPrivacyObligation.xml" ]] || [[ "$filename" == "./specgen_input/06_DataModel/Custom/Common/ReportAuthorityInfo.xml" ]] ; then
-    continue
-  fi
-  perl sifexamples.pl "$filename" >> test/siftest.xml
-done
+
+if [ -d ./specgen_input/06_DataModel/Custom/Common ]; then
+  for filename in ./specgen_input/06_DataModel/Custom/Common/*.xml; do
+  #for filename in ./specgen/GenerateSpecTool_5/bin/Debug/dist/Specification/06_DataModel/Custom/Common/*.xml; do
+    if [[ "$filename" == "./specgen_input/06_DataModel/Custom/Common/StudentScoreSet.xml" ]] ||
+       [[ "$filename" == "./specgen_input/06_DataModel/Custom/Common/PersonPrivacyObligation.xml" ]] ||
+       [[ "$filename" == "./specgen_input/06_DataModel/Custom/Common/ReportAuthorityInfo.xml" ]] ; then
+      continue
+    fi
+    perl sifexamples.pl "$filename" >> test/siftest.xml
+  done
+fi
+
+if [ -d ./specgen_input/06_DataModel/Custom/AU ]; then
+  for filename in ./specgen_input/06_DataModel/Custom/AU/*.xml; do
+    perl sifexamples.pl "$filename" >> test/siftest.xml
+  done
+fi
+
+if [ -d ./specgen_input/06_DataModel/Custom/Infrastructure ]; then
+  for filename in ./specgen_input/06_DataModel/Custom/Infrastructure/*.xml; do
+
+    # exclude the two gCore dataobjects (for now)
+    # job.xml has xsi:type= definition which isn't handled when re-generating XML From JSON - so don't include in roundtrip tests
+    if [[ "$filename" == "./specgen_input/06_DataModel/Custom/Infrastructure/gCoreStaff.xml" ]] || 
+       [[ "$filename" == "./specgen_input/06_DataModel/Custom/Infrastructure/gCoreStudent.xml" ]] ||
+       [[ "$filename" == "./specgen_input/06_DataModel/Custom/Infrastructure/job.xml" ]]; then
+      continue
+    fi
+    perl sifexamples.pl "$filename" >> test/siftest.xml
+  done
+fi
+
 echo "</sif>" >> test/siftest.xml 
-xmllint --format test/siftest.xml > test/siftest.pretty.xml
+xmllint --c14n test/siftest.xml | xmllint --format - >test/siftest.pretty.xml
 
 # 5. Test roundtrip XML > JSON (preserving order of keys) > XML
 
 xsltproc scripts/sif2json.xslt test/siftest.xml > test/siftest.json
 jq . test/siftest.json > test/siftest.pretty.json
 echo "<sif>" > test/siftest2.xml
-node scripts/json2sif.js < test/siftest.pretty.json >> test/siftest2.xml
+bash -c "node scripts/json2sif.js < test/siftest.pretty.json >> test/siftest2.xml"
 echo "</sif>" >> test/siftest2.xml
-xmllint --format test/siftest2.xml > test/siftest2.pretty.xml
+xmllint --c14n test/siftest2.xml | xmllint --format - > test/siftest2.pretty.xml
 diff test/siftest.pretty.xml test/siftest2.pretty.xml > test/diff.txt
 cat test/diff.txt
 echo "Diff lines, roundtrip: "
@@ -54,7 +74,7 @@ echo "<sif>" > test/siftest3.xml
 node scripts/json2sif.js < test/siftest.sorted.json >> test/siftest3.xml
 echo "</sif>" >> test/siftest3.xml
 xsltproc scripts/sifreorder.xslt test/siftest3.xml > test/siftest.sorted.xml
-xmllint --format test/siftest.sorted.xml > test/siftest.sorted.pretty.xml
+xmllint --c14n test/siftest.sorted.xml | xmllint --format - > test/siftest.sorted.pretty.xml
 diff test/siftest2.pretty.xml test/siftest.sorted.pretty.xml > test/diff.sorted.txt
 cat test/diff.sorted.txt
 echo "Diff lines, re-sorting XML: "

--- a/sifobject.xslt
+++ b/sifobject.xslt
@@ -61,6 +61,12 @@ The output takes the following format:
 
   <xsl:output method="text"  encoding="utf-8"/>
 
+  <!-- One pass through we'll be appending 'Type' to all the dataObject names 
+        - SpecGen builds a complexType for each dataObject
+        - Infrastructure schema re-uses some of those dataObject derived complexTypes
+    -->
+  <xsl:param name="objSuffix"/>
+
   <xsl:strip-space elements="*" />
 
   <xsl:template match="/">
@@ -80,7 +86,7 @@ The output takes the following format:
   <xsl:template match="//sif:DataObject/sif:Item[1] | //sif:CommonElement/sif:Item[1]">
     <xsl:choose>
       <xsl:when test="../sif:Item[2] | ../sif:Choice">
-        <xsl:value-of select="sif:Element"/>//
+        <xsl:value-of select="concat(sif:Element, $objSuffix)"/>//
         <xsl:if test="sif:Type">
           <xsl:text>%Inherits: </xsl:text> 
           <xsl:call-template name="type_extract">
@@ -94,7 +100,7 @@ The output takes the following format:
       <xsl:otherwise> 
         <xsl:choose>
           <xsl:when test="sif:Element">
-            <xsl:value-of select="sif:Element"/> 
+            <xsl:value-of select="concat(sif:Element, $objSuffix)"/> 
           </xsl:when>
           <xsl:otherwise>
             <xsl:value-of select="sif:Attribute"/> 


### PR DESCRIPTION
Various fixups to scripts so that:

- Scripts will run in bash on Windows as well as Linux
- Scripts work on Infrastructure spec as well as AU data model spec
- Specgen generates a complexType for each dataobject that needs to be included in typegraph
- Repeatable elements don't have to be wrapped up in List objects