### PR TITLE
Apparent Prevention

### DIFF
--- a/treeparse.rb
+++ b/treeparse.rb
@@ -1,4 +1,6 @@
 #require "byebug"
+require "pp"
+require "set"
 
 # Read in files objectgraph.txt and typegraph.txt, which contain structural information about the SIF spec as a graph,
 # and generate a single flat file containing all structural information about the spec
@@ -81,9 +83,12 @@ def xpathtype(arr, path, object)
 end
 
 @counter = 0
+@previouspathsT = Set.new
 
 def traverse(arr, path, currdepth, maxdepth, header)
   return if maxdepth > 0 && currdepth >= maxdepth
+  return if @previouspathsT.include?(path) or @previouspathsT.include?(path.chomp("/"))
+  @previouspathsT << path
   arr.each do |a|
     display = path.gsub(%r{//+}, "/").sub(%r{/+$}, "") 
     display = "#{display}/#{a[:elem]}" if a[:elem]
@@ -115,7 +120,12 @@ def traverse(arr, path, currdepth, maxdepth, header)
   end
 end
 
+@previouspathsLF = Set.new
+
 def listfind(arr, path)
+  return if @previouspathsLF.include?(path) or @previouspathsLF.include?(path.chomp("/"))
+  @previouspathsLF << path
+
   arr.each do |a|
     if a[:list] 
       puts "LIST: #{path}/#{a[:elem]}"
@@ -135,7 +145,11 @@ def listfind(arr, path)
   end
 end
 
+@previouspathsBF = Set.new
+
 def booleanfind(arr, path)
+  return if @previouspathsBF.include?(path) or @previouspathsBF.include?(path.chomp("/"))
+  @previouspathsBF << path
   arr.each do |a|
     #pp a
     if a[:type] == "boolean"
@@ -157,7 +171,11 @@ def booleanfind(arr, path)
   end
 end
 
+@previouspathsNF = Set.new
+
 def numericfind(arr, path)
+  return if @previouspathsNF.include?(path)
+  @previouspathsNF << path
   arr.each do |a|
     #pp a
     elem = a[:elem] ? ( "/" + a[:elem] ) : ""
@@ -196,8 +214,14 @@ def isSimpleType(a)
   return false if @typegraph[a[:type]] && @typegraph[a[:type]].is_a?(Array)
 end
 
+@previouspathsSAF = Set.new
+
 def simpleattrfind(arr, path)
+  return if @previouspathsSAF.include?(path)
+  @previouspathsSAF << path
   arr.each do |a|
+    #pp a
+    #byebug
     elem = a[:elem] ? ( "/" + a[:elem] ) : ""
     if a[:attr] && !a[:attr].empty? && isSimpleType(a)
       puts "SIMPLE ATTRIBUTE: #{path}#{elem}\t#{a[:type] || a[:inherits]}"
@@ -217,7 +241,11 @@ def simpleattrfind(arr, path)
   end
 end
 
+@previouspathsCAF = Set.new
+
 def complexattrfind(arr, path)
+  return if @previouspathsCAF.include?(path)
+  @previouspathsCAF << path
   #byebug
   arr.each do |a|
     #pp a

--- a/treeparse.rb
+++ b/treeparse.rb
@@ -82,13 +82,10 @@ def xpathtype(arr, path, object)
   end
 end
 
-@counter = 0
-@previouspathsT = Set.new
-
 def traverse(arr, path, currdepth, maxdepth, header)
   return if maxdepth > 0 && currdepth >= maxdepth
   return if @previouspathsT.include?(path) or @previouspathsT.include?(path.chomp("/"))
-  @previouspathsT << path
+  @previouspathsT << path unless arr[0][:inherits]
   arr.each do |a|
     display = path.gsub(%r{//+}, "/").sub(%r{/+$}, "") 
     display = "#{display}/#{a[:elem]}" if a[:elem]
@@ -120,11 +117,9 @@ def traverse(arr, path, currdepth, maxdepth, header)
   end
 end
 
-@previouspathsLF = Set.new
-
 def listfind(arr, path)
   return if @previouspathsLF.include?(path) or @previouspathsLF.include?(path.chomp("/"))
-  @previouspathsLF << path
+  @previouspathsLF << path unless arr[0][:inherits]
 
   arr.each do |a|
     if a[:list] 
@@ -145,11 +140,9 @@ def listfind(arr, path)
   end
 end
 
-@previouspathsBF = Set.new
-
 def booleanfind(arr, path)
   return if @previouspathsBF.include?(path) or @previouspathsBF.include?(path.chomp("/"))
-  @previouspathsBF << path
+  @previouspathsBF << path unless arr[0][:inherits]
   arr.each do |a|
     #pp a
     if a[:type] == "boolean"
@@ -171,11 +164,9 @@ def booleanfind(arr, path)
   end
 end
 
-@previouspathsNF = Set.new
-
 def numericfind(arr, path)
   return if @previouspathsNF.include?(path)
-  @previouspathsNF << path
+  @previouspathsNF << path unless arr[0][:inherits]
   arr.each do |a|
     #pp a
     elem = a[:elem] ? ( "/" + a[:elem] ) : ""
@@ -214,11 +205,9 @@ def isSimpleType(a)
   return false if @typegraph[a[:type]] && @typegraph[a[:type]].is_a?(Array)
 end
 
-@previouspathsSAF = Set.new
-
 def simpleattrfind(arr, path)
   return if @previouspathsSAF.include?(path)
-  @previouspathsSAF << path
+  @previouspathsSAF << path unless arr[0][:inherits]
   arr.each do |a|
     #pp a
     #byebug
@@ -241,11 +230,9 @@ def simpleattrfind(arr, path)
   end
 end
 
-@previouspathsCAF = Set.new
-
 def complexattrfind(arr, path)
   return if @previouspathsCAF.include?(path)
-  @previouspathsCAF << path
+  @previouspathsCAF << path unless arr[0][:inherits]
   #byebug
   arr.each do |a|
     #pp a
@@ -279,7 +266,17 @@ def complexattrfind(arr, path)
   end
 end
 
+def clear
+  @counter = 0
+  @previouspathsT = Set.new
+  @previouspathsLF = Set.new
+  @previouspathsBF = Set.new
+  @previouspathsNF = Set.new
+  @previouspathsSAF = Set.new
+  @previouspathsCAF = Set.new
+end
 
+clear
 objgraph = get_objgraph(File.open("objectgraph.txt", encoding: "utf-8"))
 @typegraph = get_objgraph(File.open("typegraph.txt", encoding: "utf-8"))
 
@@ -305,13 +302,13 @@ objgraph.keys.each { |k| booleanfind(objgraph[k], k) }
 objgraph.keys.each { |k| xpathtype(objgraph[k], k, "OBJECT") }
 @typegraph.keys.each { |k| xpathtype(@typegraph[k], k, "TYPE") }
 
-@counter = 0
+clear
 objgraph.keys.each { |k| traverse(objgraph[k], k, 0, 1, "TRAVERSE ALL, DEPTH 1") }
-@counter = 0
+clear
 objgraph.keys.each { |k| traverse(objgraph[k], k, 0, -1, "TRAVERSE ALL, DEPTH ALL") }
-@counter = 0
+clear
 @typegraph.keys.each { |k| traverse(@typegraph[k], k, 0, 1, "TRAVERSE COMMON TYPES, DEPTH 1") }
-@counter = 0
+clear
 @typegraph.keys.each { |k| traverse(@typegraph[k], k, 0, -1, "TRAVERSE COMMON TYPES, DEPTH ALL") }
 
 puts "END"


### PR DESCRIPTION
Include logic prevent self references based on the XPath.

As reviewed.

Could cause problems if:
- different types on the same path use the same tag name
- conversion of self referenced instances
